### PR TITLE
Enable hiding preview window's title

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ Using external grep-like program to search `display` and replace it to `show`, b
                 vline, vline, hline, hline, ulcorner, urcorner, blcorner, brcorner, sbar]],
             default = {'│', '│', '─', '─', '╭', '╮', '╰', '╯', '█'}
         },
+        show_title = {
+            description = [[show the window title]],
+            default = true
+        },
         delay_syntax = {
             description = [[delay time, to do syntax for previewed buffer, unit is millisecond]],
             default = 50
@@ -443,6 +447,7 @@ require('bqf').setup({
         win_vheight = 12,
         delay_syntax = 80,
         border_chars = {'┃', '┃', '━', '━', '┏', '┓', '┗', '┛', '█'},
+        show_title = false,
         should_preview_cb = function(bufnr, qwinid)
             local ret = true
             local bufname = vim.api.nvim_buf_get_name(bufnr)

--- a/lua/bqf/config.lua
+++ b/lua/bqf/config.lua
@@ -10,6 +10,7 @@ local config = {}
 ---@class BqfConfigPreview
 ---@field auto_preview boolean
 ---@field border_chars string[]
+---@field show_title boolean
 ---@field delay_syntax number
 ---@field win_height number
 ---@field win_vheight number
@@ -34,6 +35,7 @@ local function init()
         preview = {
             auto_preview = true,
             border_chars = {'│', '│', '─', '─', '╭', '╮', '╰', '╯', '█'},
+            show_title = true,
             delay_syntax = 50,
             win_height = 15,
             win_vheight = 15,

--- a/lua/bqf/preview/border.lua
+++ b/lua/bqf/preview/border.lua
@@ -18,26 +18,14 @@ function Border:build(o)
     self.__index = self
     self.floatwin = FloatWin
     self.chars = o.chars
+    self.showTitle = o.showTitle
     self.winid = 0
     self.bufnr = 0
     return self
 end
 
 function Border:update(pbufnr, idx, size)
-    local posStr = ('[%d/%d]'):format(idx, size)
-    local bufStr = ('buf %d:'):format(pbufnr)
-    local modified = vim.bo[pbufnr].modified and '[+] ' or ''
-    local name = fn.bufname(pbufnr):gsub('^' .. vim.env.HOME, '~')
-    local width = api.nvim_win_get_width(self.winid)
-    local padFit = width - 10 - fn.strwidth(bufStr) - fn.strwidth(posStr)
-    if padFit - fn.strwidth(name) < 0 then
-        name = fn.pathshorten(name)
-        if padFit - fn.strwidth(name) < 0 then
-            name = ''
-        end
-    end
-    local title = (' %s %s %s %s'):format(posStr, bufStr, name, modified)
-    self:updateTitle(title)
+    self:updateTitle(pbufnr, idx, size)
     self:updateScrollBar()
 end
 
@@ -94,7 +82,24 @@ function Border:updateScrollBar()
     api.nvim_buf_set_lines(self.bufnr, 1, -2, false, lines)
 end
 
-function Border:updateTitle(title)
+function Border:updateTitle(pbufnr, idx, size)
+    if not self.showTitle then
+        return
+    end
+
+    local posStr = ('[%d/%d]'):format(idx, size)
+    local bufStr = ('buf %d:'):format(pbufnr)
+    local modified = vim.bo[pbufnr].modified and '[+] ' or ''
+    local name = fn.bufname(pbufnr):gsub('^' .. vim.env.HOME, '~')
+    local width = api.nvim_win_get_width(self.winid)
+    local padFit = width - 10 - fn.strwidth(bufStr) - fn.strwidth(posStr)
+    if padFit - fn.strwidth(name) < 0 then
+        name = fn.pathshorten(name)
+        if padFit - fn.strwidth(name) < 0 then
+            name = ''
+        end
+    end
+    local title = (' %s %s %s %s'):format(posStr, bufStr, name, modified)
     local top = api.nvim_buf_get_lines(self.bufnr, 0, 1, 0)[1]
     local prefix = fn.strcharpart(top, 0, 3)
     local suffix = fn.strcharpart(top, fn.strwidth(title) + 3, fn.strwidth(top))

--- a/lua/bqf/preview/handler.lua
+++ b/lua/bqf/preview/handler.lua
@@ -10,6 +10,7 @@ local shouldPreviewCallback
 local keepPreview, origPos
 local winHeight, winVHeight
 local wrap, borderChars
+local showTitle
 local lastIdx
 local PLACEHOLDER_TBL
 
@@ -366,6 +367,7 @@ function M.initialize(qwinid)
         winVHeight = winVHeight,
         wrap = wrap,
         borderChars = borderChars,
+        showTitle = showTitle,
         focusable = mouseEnabled
     })
     -- some plugins will change the quickfix window, preview window should init later
@@ -400,6 +402,7 @@ local function init()
     wrap = pconf.wrap
     shouldPreviewCallback = pconf.should_preview_cb
     borderChars = pconf.border_chars
+    showTitle = pconf.show_title
     winHeight = tonumber(pconf.win_height)
     winVHeight = tonumber(pconf.win_vheight or winHeight)
     vim.validate({
@@ -412,6 +415,7 @@ local function init()
                 return type(chars) == 'table' and #chars == 9
             end, 'a table with 9 chars'
         },
+        show_title = {showTitle, 'boolean'},
         win_height = {winHeight, 'number'},
         win_vheight = {winVHeight, 'number'}
     })

--- a/lua/bqf/preview/session.lua
+++ b/lua/bqf/preview/session.lua
@@ -19,6 +19,7 @@ local scrollThrottled
 ---@field winVHeight number
 ---@field wrap boolean
 ---@field borderChars string[]
+---@field showTitle boolean
 ---@field bufnr number
 ---@field syntax boolean
 ---@field full boolean
@@ -39,6 +40,7 @@ function PreviewSession:new(winid, o)
     obj.winVHeight = o.winVHeight
     obj.wrap = o.wrap
     obj.borderChars = o.borderChars
+    obj.showTitle = o.showTitle
     obj.bufnr = nil
     obj.syntax = nil
     obj.full = false
@@ -175,7 +177,7 @@ function PreviewSession:validOrBuild(owinid)
         end
     end
     if not isValid then
-        border:build({chars = self.borderChars})
+        border:build({chars = self.borderChars, showTitle = self.showTitle})
     end
     if self.full then
         floatwin:setHeight(999, 999)


### PR DESCRIPTION
Add two new options, `show_title` and `show_scrollbar`, that controls whether the preview window will display a title and a scrollbar indicator, respectively. This should help people make their preview window more minimalist if they don't need a title and/or a scrollbar.