### PR TITLE
fix(preview): Fix invalid window id error on updateScrollBar

### DIFF
--- a/lua/bqf/preview/border.lua
+++ b/lua/bqf/preview/border.lua
@@ -55,9 +55,6 @@ function Border:updateBuf(opts)
 end
 
 function Border:updateScrollBar()
-    if not api.nvim_win_is_valid(self.floatwin.winid) then
-        return
-    end
     local buf = api.nvim_win_get_buf(self.floatwin.winid)
     local lineCount = api.nvim_buf_line_count(buf)
 

--- a/lua/bqf/preview/border.lua
+++ b/lua/bqf/preview/border.lua
@@ -55,6 +55,9 @@ function Border:updateBuf(opts)
 end
 
 function Border:updateScrollBar()
+    if not api.nvim_win_is_valid(self.floatwin.winid) then
+        return
+    end
     local buf = api.nvim_win_get_buf(self.floatwin.winid)
     local lineCount = api.nvim_buf_line_count(buf)
 

--- a/lua/bqf/preview/session.lua
+++ b/lua/bqf/preview/session.lua
@@ -200,7 +200,9 @@ local function init()
         self.mapBufHighlight((self.get() or {}).bufnr)
     end, 50)
     self.scrollThrottled = throttle(function()
-        border:updateScrollBar()
+        if self.validate() then
+            border:updateScrollBar()
+        end
     end, 80)
 end
 


### PR DESCRIPTION
In some cases (e.g., mouse scrolling in the quickfix window),
the preview window may throw an "Invalid window id" error.
Probably because of a data race where the floating window is gone.

To avoid such an error, we can check whether the window is valid
before doing window-related operations.

Detailed error information:

```
Error executing vim.schedule lua callback:
    .../nvim-bqf/lua/bqf/preview/border.lua:58: Invalid window id: 1167
stack traceback:
    [C]: in function 'nvim_win_get_buf'
    .../nvim-bqf/lua/bqf/preview/border.lua:58: in function 'updateScrollBar'
    .../nvim-bqf/lua/bqf/preview/session.lua:203: in function ''
```
