### PR TITLE
feat(preview): Add new options win_width and win_vwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,18 @@ Using external grep-like program to search `display` and replace it to `show`, b
             description = [[the height of preview window for vertical layout]],
             default = 15
         },
+        win_width = {
+            description = [[the width of preview window for horizontal layout,
+                denotes the width in characters if a positive integer is given,
+                or the ratio (between 0 and 1) to the quickfix window's width if a real number is given.]]
+            default = 1.0,
+        }
+        win_vwidth = {
+            description = [[the width of preview window for vertical layout,
+                denotes the width in characters if a positive integer is given,
+                or the ratio (between 0 and 1) to the quickfix window's width if a real number is given.]]
+            default = 1.0,
+        }
         wrap = {
             description = [[wrap the line, `:h wrap` for detail]],
             default = false

--- a/lua/bqf/config.lua
+++ b/lua/bqf/config.lua
@@ -17,6 +17,8 @@ local def = {
         delay_syntax = 50,
         win_height = 15,
         win_vheight = 15,
+        win_width = 1.0,
+        win_vwidth = 1.0,
         wrap = false,
         should_preview_cb = nil
     },
@@ -70,6 +72,8 @@ local def = {
 ---@field delay_syntax number
 ---@field win_height number
 ---@field win_vheight number
+---@field win_width number
+---@field win_vwidth number
 ---@field wrap boolean
 ---@field should_preview_cb fun(bufnr: number, qwinid: number): boolean
 

--- a/lua/bqf/preview/handler.lua
+++ b/lua/bqf/preview/handler.lua
@@ -8,7 +8,7 @@ local autoPreview
 local clicked
 local shouldPreviewCallback
 local keepPreview, origPos
-local winHeight, winVHeight
+local winHeight, winVHeight, winWidth, winVWidth
 local wrap, borderChars
 local showTitle
 local lastIdx
@@ -400,6 +400,8 @@ function M.initialize(qwinid)
     pvs:new(qwinid, {
         winHeight = winHeight,
         winVHeight = winVHeight,
+        winWidth = winWidth,
+        winVWidth = winVWidth,
         wrap = wrap,
         borderChars = borderChars,
         showTitle = showTitle,
@@ -440,6 +442,8 @@ local function init()
     showTitle = pconf.show_title
     winHeight = tonumber(pconf.win_height)
     winVHeight = tonumber(pconf.win_vheight or winHeight)
+    winWidth = tonumber(pconf.win_width)
+    winVWidth = tonumber(pconf.win_vwidth or winWidth)
     vim.validate({
         auto_preview = {autoPreview, 'boolean'},
         delay_syntax = {delaySyntax, 'number'},
@@ -452,7 +456,17 @@ local function init()
         },
         show_title = {showTitle, 'boolean'},
         win_height = {winHeight, 'number'},
-        win_vheight = {winVHeight, 'number'}
+        win_vheight = {winVHeight, 'number'},
+        win_width = {
+            winWidth, function(w)
+                return type(w) == 'number' and w > 0
+            end, 'a positive integer, or real number in range [0, 1]'
+        },
+        win_vwidth = {
+            winVWidth, function(w)
+                return type(w) == 'number' and w > 0
+            end, 'a positive integer, or real number in range [0, 1]'
+        },
     })
 
     cmd([[

--- a/lua/bqf/preview/session.lua
+++ b/lua/bqf/preview/session.lua
@@ -15,6 +15,8 @@ local throttle = require('bqf.lib.throttle')
 ---@field winid number
 ---@field winHeight number
 ---@field winVHeight number
+---@field winWidth number
+---@field winVWidth number
 ---@field wrap boolean
 ---@field borderChars string[]
 ---@field showTitle boolean
@@ -39,6 +41,8 @@ function PreviewSession:new(winid, o)
     obj.winid = winid
     obj.winHeight = o.winHeight
     obj.winVHeight = o.winVHeight
+    obj.winWidth = o.winWidth
+    obj.winVWidth = o.winVWidth
     obj.wrap = o.wrap
     obj.borderChars = o.borderChars
     obj.showTitle = o.showTitle
@@ -189,6 +193,7 @@ function PreviewSession:validOrBuild(owinid)
         floatwin:setHeight(999, 999)
     else
         floatwin:setHeight(self.winHeight, self.winVHeight)
+        floatwin:setWidth(self.winWidth, self.winVWidth)
     end
     return isValid
 end


### PR DESCRIPTION
Similar to win_height and win_vheight, the newly introduced options
win_width and win_vwidth specifies the width of the preview window
(defaults remain the same, the full width).

The option values can be a real number between [0..1] (the ratio
relative to the full width) or a positive integer (characters).
