### PR TITLE
feat(preview): support format_title config

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ Using external grep-like program to search `display` and replace it to `show`, b
             description = [[Show the window title]],
             default = true
         },
+        format_title = {
+            description = [[Format the window title]],
+            default = nil
+        },
         show_scroll_bar = {
             description = [[Show the scroll bar]],
             default = true

--- a/lua/bqf/config.lua
+++ b/lua/bqf/config.lua
@@ -14,6 +14,7 @@ local def = {
         auto_preview = true,
         border = 'rounded',
         show_title = true,
+        format_title = nil,
         show_scroll_bar = true,
         delay_syntax = 50,
         winblend = 12,
@@ -70,6 +71,7 @@ local def = {
 ---@field auto_preview boolean
 ---@field border string|string[]
 ---@field show_title boolean
+---@field format_title fun(info: { bufnr: integer, idx: integer, size: integer, max_width: integer }): string
 ---@field show_scroll_bar boolean
 ---@field delay_syntax number
 ---@field win_height number

--- a/lua/bqf/preview/handler.lua
+++ b/lua/bqf/preview/handler.lua
@@ -453,7 +453,7 @@ local function init()
     autoPreview = pconf.auto_preview
     shouldPreviewCallback = pconf.should_preview_cb
     local wrap, winblend = pconf.wrap, pconf.winblend
-    local showTitle, showScrollBar = pconf.show_title, pconf.show_scroll_bar
+    local showTitle, formatTitle, showScrollBar = pconf.show_title, pconf.format_title, pconf.show_scroll_bar
     local winHeight = tonumber(pconf.win_height)
     local winVHeight = tonumber(pconf.win_vheight or winHeight)
     bufLabel = pconf.buf_label
@@ -463,6 +463,7 @@ local function init()
         should_preview_cb = {shouldPreviewCallback, 'function', true},
         wrap = {wrap, 'boolean'},
         show_title = {showTitle, 'boolean'},
+        format_title = {formatTitle, 'function', true},
         show_scroll_bar = {showScrollBar, 'boolean'},
         win_height = {winHeight, 'number'},
         win_vheight = {winVHeight, 'number'},
@@ -473,6 +474,7 @@ local function init()
         border = pconf.border,
         wrap = wrap,
         showTitle = showTitle,
+        formatTitle = formatTitle,
         showScrollBar = showScrollBar,
         winHeight = winHeight,
         winVHeight = winVHeight,

--- a/lua/bqf/preview/session.lua
+++ b/lua/bqf/preview/session.lua
@@ -188,7 +188,7 @@ end
 
 function PreviewSession:initialize(o)
     self.ns = api.nvim_create_namespace('bqf-preview')
-    floatwin:initialize(self.ns, o.border, o.wrap, o.winHeight, o.winVHeight, o.winblend)
+    floatwin:initialize(self.ns, o.border, o.wrap, o.winHeight, o.winVHeight, o.winblend, o.formatTitle)
     self.enableTitle = o.showTitle
     self.enableScrollBar = o.showScrollBar
     if self.enableScrollBar then


### PR DESCRIPTION
<details>
<summary>The current way of doing this is very hacky.</summary>

```lua
require("bqf.preview.floatwin").generateTitle = function (self, bufnr, idx, size)
  local position = (" [%d/%d] "):format(idx, size)
  local buffer = ("buf %d: "):format(bufnr)
  local flags = vim.bo[bufnr].modified and " [+] " or " "
  local max_width = self.width - 4 - vim.fn.strwidth(buffer) - vim.fn.strwidth(position) - vim.fn.strwidth(flags)

  local fname = vim.fn.fnamemodify(vim.fn.bufname(bufnr), ":p:~:.")

  local attempt = 3
  while max_width < vim.fn.strwidth(fname) do
    if attempt == -1 then
      fname = ""
      break
    elseif attempt == 0 then
      fname = vim.fn.fnamemodify(fname, ":t")
    else
      fname = vim.fn.pathshorten(fname, attempt * 2 - 1)
    end
    attempt = attempt - 1
  end

  return ("%s%s%s%s"):format(position, buffer, fname, flags)
end
```
</details>

This config will enable user to do it cleanly:

```lua
local function format_title(info)
  local bufnr = info.bufnr
  local position = (" [%d/%d] "):format(info.idx, info.size)
  local buffer = ("buf %d: "):format(bufnr)
  local flags = vim.bo[bufnr].modified and " [+] " or " "
  local max_width = info.max_width - vim.fn.strwidth(buffer) - vim.fn.strwidth(position) - vim.fn.strwidth(flags)

  local fname = vim.fn.fnamemodify(vim.fn.bufname(bufnr), ":p:~:.")

  local attempt = 3
  while max_width < vim.fn.strwidth(fname) do
    if attempt == -1 then
      fname = ""
      break
    elseif attempt == 0 then
      fname = vim.fn.fnamemodify(fname, ":t")
    else
      fname = vim.fn.pathshorten(fname, attempt * 2 - 1)
    end
    attempt = attempt - 1
  end

  return ("%s%s%s%s"):format(position, buffer, fname, flags)
end

require("bqf").setup({
  preview = {
    format_title = format_title,
  },
})
```

Outside current directory (under root):

<img width="826" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/ffcbf2aa-0a0c-46b0-ab43-9a4c16ad3780">  

Outside current directory (under home):
 
<img width="747" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/116f2297-0fca-41a4-9970-62f2e7ef1fd6">  

Inside current directory:

<img width="357" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/5665160d-fd62-442c-93a0-e794ebd38723">  

**Truncations**:

3:

<img width="575" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/c505be45-eeae-4910-b86f-0a3725b5c7f8">  

2:

<img width="527" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/373244e4-718f-4760-b35f-f3ae98a294a0">  

1:

<img width="476" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/6418211c-981e-4c98-afe8-397e94f2aef4">  

0:

<img width="420" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/af1c4145-dba9-4d6f-8b35-65d4869234a6">  

-1:

<img width="201" alt="image" src="https://github.com/kevinhwang91/nvim-bqf/assets/8050659/31399459-fb0b-4590-be63-2e657e48055d">  
