### PR TITLE
feat(config): Add option to enable or disable mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Using external grep-like program to search `display` and replace it to `show`, b
             any floating attributes.]],
         default = true
     },
+    enable_mouse = {
+        description = [[Enable item selection mouse keymaps]],
+        default = true
+    },
     auto_resize_height = {
         description = [[Resize quickfix window height automatically.
             Shrink higher height to size of list in quickfix window, otherwise extend height

--- a/lua/bqf/config.lua
+++ b/lua/bqf/config.lua
@@ -2,6 +2,7 @@
 ---@field auto_enable boolean
 ---@field magic_window boolean
 ---@field auto_resize_height boolean
+---@field enable_mouse boolean
 ---@field preview BqfConfigPreview
 ---@field func_map table<string, string>
 ---@field filter BqfConfigFilter
@@ -9,6 +10,7 @@ local def = {
     auto_enable = true,
     magic_window = true,
     auto_resize_height = false,
+    enable_mouse = true,
     previous_winid_ft_skip = {},
     preview = {
         auto_preview = true,
@@ -96,6 +98,7 @@ local function init()
     vim.validate({
         auto_enable = {Config.auto_enable, 'boolean'},
         magic_window = {Config.magic_window, 'boolean'},
+        enable_mouse = {Config.enable_mouse, 'boolean'},
         auto_resize_height = {Config.auto_resize_height, 'boolean'},
         preview = {Config.preview, 'table'},
         func_map = {Config.func_map, 'table'},

--- a/lua/bqf/filter/fzf.lua
+++ b/lua/bqf/filter/fzf.lua
@@ -485,7 +485,7 @@ function M.preHandle(qwinid, size, bind)
         end
     end
 
-    if vim.o.mouse:match('[na]') ~= nil then
+    if vim.o.mouse:match('[na]') ~= nil and config.enable_mouse then
         api.nvim_buf_set_keymap(bufnr, 'n', '<LeftMouse>',
                                 [[<Cmd>lua require('bqf.preview.handler').mouseClick('t')<CR>]],
                                 {nowait = true, noremap = false})

--- a/lua/bqf/keymap.lua
+++ b/lua/bqf/keymap.lua
@@ -169,13 +169,16 @@ function M.initialize()
             )
         end
     end
-    api.nvim_buf_set_keymap(
-        0,
-        'n',
-        '<2-LeftMouse>',
-        '<CR>',
-        {desc = 'Open the item under the cursor', nowait = true, noremap = false}
-    )
+
+    if vim.o.mouse:match('[na]') ~= nil and config.enable_mouse then
+        api.nvim_buf_set_keymap(
+            0,
+            'n',
+            '<2-LeftMouse>',
+            '<CR>',
+            {desc = 'Open the item under the cursor', nowait = true, noremap = false}
+        )
+    end
 end
 
 ---

--- a/lua/bqf/preview/handler.lua
+++ b/lua/bqf/preview/handler.lua
@@ -459,7 +459,7 @@ function M.initialize(qwinid)
         aug END
     ]])
 
-    local mouseEnabled = vim.o.mouse:match('[na]') ~= nil
+    local mouseEnabled = vim.o.mouse:match('[na]') ~= nil and config.enable_mouse
 
     pvs:new(qwinid, mouseEnabled)
     -- some plugins will change the quickfix window, preview window should init later


### PR DESCRIPTION
Add an `enable_mouse` option to enable/disable mouse mappings.

This is useful for me because I have my own quickfix mouse mappings and the ones in bqf interfere with them.