### PR TITLE
fix(qfwin): avoid nil errors upon saveWinView

### DIFF
--- a/lua/bqf/qfwin/session.lua
+++ b/lua/bqf/qfwin/session.lua
@@ -91,8 +91,10 @@ end
 function QfSession:saveWinView(winid)
     if winid then
         local obj = self.pool[winid]
-        local wv = utils.winCall(winid, fn.winsaveview)
-        obj:list():setWinView(wv)
+        if obj then
+            local wv = utils.winCall(winid, fn.winsaveview)
+            obj:list():setWinView(wv)
+        end
     end
 end
 


### PR DESCRIPTION
Quickfix buffers can be placed on other windows not necessarily open
through `:copen`-like commands. In such cases, QfSession for some
windows may not exist; in fact, those do not need to save view states.

```
Error detected while processing WinLeave Autocommands for "<buffer=53>":
E5108: Error executing lua .../nvim-bqf/lua/bqf/qfwin/session.lua:95: attempt to index local 'obj'
(a nil value)
stack traceback:
        .../nvim-bqf/lua/bqf/qfwin/session.lua:95: in function 'saveWinView'
        .../nvim-bqf/lua/bqf/main.lua:103: in function 'saveWinView'
        [string ":lua"]:1: in main chunk
```
