### PR TITLE
fix(preview): gracefully handle `nvim-treesitter` `main` branch

### DIFF
--- a/lua/bqf/preview/treesitter.lua
+++ b/lua/bqf/preview/treesitter.lua
@@ -116,6 +116,18 @@ local function init()
     if not initialized then
         return
     end
+    if parsers.get_parser == nil then
+        -- NOTE: nvim-treesitter main branch is used.
+        -- https://github.com/nvim-treesitter/nvim-treesitter/blob/main/lua/nvim-treesitter/parsers.lua
+        -- Users should have their own autocommands for starting Treesitter parsers
+        -- in buffers, including the `qf` buffer. We do not need to handle it for them.
+        initialized = false
+        parsers = nil
+        return
+    end
+
+    -- NOTE: nvim-treesitter master branch is used.
+    -- https://github.com/nvim-treesitter/nvim-treesitter/blob/master/lua/nvim-treesitter/parsers.lua
     initialized = true
     configs = require('nvim-treesitter.configs')
     lru = require('bqf.struct.lru')


### PR DESCRIPTION
## Problem

The `main` branch of `nvim-treesitter` is not compatible with the `master` branch. The API has changed:
- `nvim-treesitter.parsers` only contains a table with parser information, no additional functions
- `nvim-treesitter.configs` does not exist
- users should set up their own autocommands to start Treesitter in buffers, including the `qf` buffer.

When opening the quickfix list, nvim-bqf throws an error because it cannot `require('nvim-treesitter.configs')`.

## Solution

Detect when the user is on the `main` branch of `nvim-treesitter`, and act as if Treesitter is not enabled at all.

If the user has an autocmd that calls `vim.treesitter.start()` in new buffers, like `nvim-treesitter` recommends, then it will start automatically for the preview buffer displayed by nvim-bqf.

This fixes the errors that are currently shown when opening the quickfix list with `nvim-bqf` when using the `main` branch of `nvim-treesitter`.

## Before


https://github.com/user-attachments/assets/d02a1702-d7a6-4bcd-b385-e9a7f92b97f9



## After


https://github.com/user-attachments/assets/a328decd-845c-4dfe-81c3-630430973fb8

