### PR TITLE
fix: small typo in the example config at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Using external grep-like program to search `display` and replace it to `show`, b
         winblend = {
             description = [[The winblend for preview window, `:h winblend`]],
             default = 12
-        }
+        },
         wrap = {
             description = [[Wrap the line, `:h wrap` for detail]],
             default = false


### PR DESCRIPTION
Just a small typo. I usually copy the default configs to setup my install so I have a base reference of what I can change, and my neovim detected the syntax issue.